### PR TITLE
Opt rdma output event wait and wakeup

### DIFF
--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -139,7 +139,7 @@ void SamplerCollector::run() {
     // NOTE:
     // * Following vars can't be created on thread's stack since this thread
     //   may be abandoned at any time after forking.
-    // * They can't created inside the constructor of SamplerCollector as well,
+    // * They can't be created inside the constructor of SamplerCollector as well,
     //   which results in deadlock.
     if (s_cumulated_time_bvar == NULL) {
         s_cumulated_time_bvar =


### PR DESCRIPTION
1. Ensure writing thread doesn't miss wake-up signals.
2. Writing thread is only woken up when the threshold is exceeded after a window update, thus reducing unnecessary wake-up operations.

### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
