### PR TITLE
Fix missed wakeup in ParkingLot waiter check

### DIFF
--- a/src/bthread/parking_lot.h
+++ b/src/bthread/parking_lot.h
@@ -49,10 +49,51 @@ public:
 
     // Wake up at most `num_task' workers.
     // Returns #workers woken up.
+    //
+    // When _no_signal_when_no_waiter is enabled, signal() and wait() form a
+    // Dekker-style synchronization. Both sides must preserve StoreLoad order:
+    //
+    //   signal(): _pending_signal += 2;  load(_waiter_num)
+    //   wait():   _waiter_num += 1;      futex_wait(_pending_signal)
+    //
+    // Without the matching seq_cst fences, the following lost-wakeup outcome
+    // is possible, because each side may observe the other side's old value:
+    //
+    //   signaler                         waiter
+    //   --------                         ------
+    //   _pending_signal += 2
+    //                                    _waiter_num += 1
+    //   load(_waiter_num) == 0
+    //   return without futex_wake()
+    //                                    futex_wait(old_pending_signal)
+    //                                    -> worker sleeps
+    //
+    // With the fences below, the lost-wakeup outcome is prevented:
+    //
+    //   signaler                         waiter
+    //   --------                         ------
+    //   _pending_signal += 2
+    //   seq_cst fence
+    //                                    _waiter_num += 1
+    //                                    seq_cst fence
+    //   load(_waiter_num)
+    //     |
+    //     +-- > 0: futex_wake() -------> waiter is woken, or has not slept yet
+    //     |
+    //     +-- == 0: return
+    //                                    futex_wait(old_pending_signal)
+    //                                    -> sees new _pending_signal; does not sleep
+    //
+    // Thus, signal() either observes a published waiter and wakes it, or the
+    // waiter observes the published signal before it can sleep.
     int signal(int num_task) {
         _pending_signal.fetch_add((num_task << 1), butil::memory_order_release);
-        if (_no_signal_when_no_waiter && _waiter_num.load(butil::memory_order_relaxed) == 0) {
-            return 0;
+        if (_no_signal_when_no_waiter) {
+            // Matching StoreLoad fence for the waiter-side fence below.
+            butil::atomic_thread_fence(butil::memory_order_seq_cst);
+            if (_waiter_num.load(butil::memory_order_relaxed) == 0) {
+                return 0;
+            }
         }
         return futex_wake_private(&_pending_signal, num_task);
     }
@@ -71,6 +112,9 @@ public:
         }
         if (_no_signal_when_no_waiter) {
             _waiter_num.fetch_add(1, butil::memory_order_relaxed);
+            // Matching StoreLoad fence for the signal-side fence above. It also orders
+            // this waiter publication before futex_wait checks _pending_signal.
+            butil::atomic_thread_fence(butil::memory_order_seq_cst);
         }
         futex_wait_private(&_pending_signal, expected_state.val, NULL);
         if (_no_signal_when_no_waiter) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

When `--parking_lot_no_signal_when_no_waiter` is enabled, `ParkingLot::signal()` avoids
calling `futex_wake_private()` when `_waiter_num` is zero.

However, the optimization introduces a Store-Load synchronization requirement between
`signal()` and `wait()`:

- `signal()` increments `_pending_signal`, then checks `_waiter_num`.
- `wait()` increments `_waiter_num`, then lets `futex_wait_private()` check
  `_pending_signal` and enqueue the worker.

The original relaxed waiter-counter accesses do not prevent both sides from observing
stale values. As a result, the signaler may decide that no worker is waiting while a
worker concurrently observes the old signal state and enters futex wait. No wakeup is
issued for that worker, causing a lost wakeup until a later signal arrives.

Timing of the problematic interleaving:

```text
signaler thread                         waiter thread
---------------                         -------------
_pending_signal += 2  (signal published)

                                        observes old _pending_signal
                                        _waiter_num += 1

load(_waiter_num) == 0
return without futex_wake_private()

                                        futex_wait_private(
                                            &_pending_signal, old_state)
                                        -> state still matches old_state
                                        -> worker sleeps

No futex wakeup is issued for this signal.
The worker remains parked until a subsequent signal wakes it up.
```

This is a Dekker-style Store-Load race: each side publishes its own state and then
observes the other side's state. Without matching Store-Load ordering, both sides may
observe the previous value.

### What is changed and the side effects?

Changed:

- Add a sequentially consistent fence in ParkingLot::signal() after publishing the pending signal and before loading _waiter_num.
- Add the matching sequentially consistent fence in ParkingLot::wait() after incrementing _waiter_num and before entering futex_wait_private().

The two fences establish the required Store-Load ordering, ensuring that a signaler
cannot skip futex_wake_private() while a concurrent waiter misses that signal and
successfully parks.

Timing after the fix:

```text
signaler thread                                  waiter thread
---------------                                  -------------
_pending_signal += 2  (release)

seq_cst fence
  |
  |  The Store-Load ordering is established with the matching fence below.
  |  Therefore, both sides cannot simultaneously observe the other side's
  |  old value.
  |

                                                  observes old _pending_signal
                                                  _waiter_num += 1

                                                  seq_cst fence
                                                    |
                                                    |  _waiter_num publication is
                                                    |  ordered before futex_wait's
                                                    |  state check.
                                                    v

load(_waiter_num)
  |
  +-- _waiter_num > 0 --------------------------> futex_wait_private(
  |                                                &_pending_signal, old_state)
  |                                                -> waiter is queued / waiting
  |                                                -> futex_wake_private() wakes it
  |
  +-- _waiter_num == 0
       |
       +-- waiter has not published itself yet
           |
           +-- waiter subsequently checks _pending_signal
               -> observes the updated state
               -> futex_wait_private() returns immediately
               -> worker does not sleep
```

Equivalently, the two valid outcomes are:
```text
Case 1: waiter is visible first
--------------------------------
waiter:   _waiter_num += 1; seq_cst fence
signaler: _pending_signal += 2; seq_cst fence; load(_waiter_num) > 0
signaler: futex_wake_private()
result:   the waiter is woken, or observes the changed futex value and does not sleep.

Case 2: signal is visible first
--------------------------------
signaler: _pending_signal += 2; seq_cst fence; load(_waiter_num) == 0
signaler: return without futex_wake_private()
waiter:   _waiter_num += 1; seq_cst fence; futex_wait_private(..., old_state)
result:   futex value no longer matches old_state; futex_wait_private() returns
          immediately and the waiter does not sleep.

```

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
