### PR TITLE
Fix bthread_join memory visibility with paired release/acquire on version_butex

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -520,9 +520,18 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
 #ifdef BRPC_BTHREAD_TRACER
             tracing = TaskTracer::set_end_status_unsafe(m);
 #endif // BRPC_BTHREAD_TRACER
-            if (0 == ++*m->version_butex) {
-                ++*m->version_butex;
+            // Bump the version with a release store so that it pairs with the
+            // acquire load in TaskGroup::join(): all memory writes made by this
+            // bthread become visible to the joining thread. Accessing
+            // version_butex atomically also avoids a data race with the read in
+            // join(). This path is the only writer of version_butex at runtime.
+            auto* version = reinterpret_cast<butil::atomic<int>*>(m->version_butex);
+            uint32_t next_version = static_cast<uint32_t>(
+                version->load(butil::memory_order_relaxed)) + 1;
+            if (0 == next_version) {
+                ++next_version;
             }
+            version->store(static_cast<int>(next_version), butil::memory_order_release);
         }
         butex_wake_except(m->version_butex, 0);
 
@@ -709,16 +718,18 @@ int TaskGroup::join(bthread_t tid, void** return_value) {
         return EINVAL;
     }
     const uint32_t expected_version = get_version(tid);
-    while (*m->version_butex == expected_version) {
-        if (butex_wait(m->version_butex, expected_version, NULL) < 0 &&
+    // Acquire load pairs with the release store performed when the joined
+    // bthread ends (see the version bump above), ensuring all of its memory
+    // writes are visible after join() returns. This matches the semantic
+    // guarantee provided by pthread_join() across supported architectures.
+    auto* version = reinterpret_cast<butil::atomic<int>*>(m->version_butex);
+    const int expected_version_int = static_cast<int>(expected_version);
+    while (version->load(butil::memory_order_acquire) == expected_version_int) {
+        if (butex_wait(m->version_butex, expected_version_int, NULL) < 0 &&
             errno != EWOULDBLOCK && errno != EINTR) {
             return errno;
         }
     }
-    // Ensure all memory writes made by the joined bthread are visible to
-    // the joining thread after join returns. This matches the semantic
-    // guarantee provided by pthread_join() across supported architectures.
-    butil::atomic_thread_fence(butil::memory_order_acquire);
     if (return_value) {
         *return_value = NULL;
     }

--- a/src/bthread/task_meta.h
+++ b/src/bthread/task_meta.h
@@ -85,10 +85,17 @@ struct TaskMeta {
     // Scheduling of the thread can be delayed.
     bool about_to_quit{false};
     
-    // [Not Reset] guarantee visibility of version_butex.
+    // [Not Reset] Serializes the version bump at bthread end (in task_runner)
+    // with accessors that validate the version before touching other fields of
+    // this TaskMeta (get_attr/set_stopped/interrupt/set_butex_waiter/...). It
+    // makes their "check version then read/write field" sequence atomic w.r.t.
+    // the bump, so they never operate on a slot that got recycled in between.
     pthread_spinlock_t version_lock{};
-    
-    // [Not Reset] only modified by one bthread at any time, no need to be atomic
+
+    // [Not Reset] Backed by a butex (internally `butil::atomic<int>`). The version
+    // bump at bthread end is published with a release store, and join() observes
+    // it with an acquire load so the joined bthread's prior writes are visible
+    // after join() returns.
     uint32_t* version_butex{NULL};
 
     // The identifier. It does not have to be here, however many code is


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #3274

Problem Summary:

The join/end handshake on `version_butex` was not correctly synchronized.
  - Producer (`task_runner`, at bthread end): bumped the version with a plain write 
    `++*m->version_butex`. The surrounding `version_lock` provides release semantics 
    only to threads that also take that lock — `join()` does not, so there is no release on 
    `version_butex` for the join path.
  - Consumer (`TaskGroup::join`): exited its wait loop via a plain read `*m->version_butex`, 
     with no acquire ordering.

The result is a data race with no happens-before edge, so writes the joined bthread made 
before ending were not guaranteed visible after `join()` returned. On x86 (TSO) the hardware 
masked this; on ARM it surfaced.

PR #3276 attempted a fix by adding a lone `atomic_thread_fence(acquire)` after the loop. But 
per the C++ memory model an acquire fence only establishes synchronization when a preceding 
atomic load reads a value from a matching release operation. Here the load was a plain read and 
the producer had no release store, so the fence pairs with nothing — it happens to work on ARM 
only because the compiler emits a real `dmb ishld`, not because the model guarantees it. 

### What is changed and the side effects?

Changed:

This PR replaces that band-aid with a properly paired release/acquire on `version_butex`.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
